### PR TITLE
Fix cache dir format 

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Get cache dir
         id: cache-dir
         run: |
-          echo "CACHE_DIR=$(Rscript -e 'bbsBayes:::bbs_dir()')" >> $GITHUB_OUTPUT
+          echo "CACHE_DIR=$(Rscript -e 'bbsBayes:::bbs_dir()' | sed -E 's/.*"(.+)"/\1/')" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache BBS data


### PR DESCRIPTION
The problem was that the `Rscript` output the dir wrapped in `[1] "<dir>"` which is ofc a dir that does not exists :grin:. I have added a bit of sed to extract the actual dir.