### PR TITLE
insert st_make_valid into assign prov state

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -168,6 +168,7 @@ assign_prov_state <- function(strata_map, min_overlap = 0.75, plot = FALSE,
     dplyr::group_by(.data$strata_name) %>%
     dplyr::summarize() %>%
     sf::st_set_agr("constant") %>%
+    sf::st_make_valid() %>%
     sf::st_intersection(ps) %>%
     dplyr::mutate(area = sf::st_area(.))
 


### PR DESCRIPTION
I added one line to the assign_prov_state function that removes the CPL_geos error we discussed today. 

This is the code that I used to produce the hexagonal grid:

```{r}
# load a base map to define the regions covered by an arbitrary regular grid
prov_state_map <- load_map("prov_state") %>%
  st_union() %>%
  st_buffer(dist = 1e4) #10 km buffer to catch routes that start near the coast

# establish a 200km * 200km regular hexagonal grid over the base map
poly_grid <- sf::st_make_grid(prov_state_map,
                              square = F,
                              cellsize = 1000*c(200, 200)) %>% 
  sf::st_sf()

crd <- st_coordinates(st_centroid(poly_grid))
poly_grid <- poly_grid %>%
  mutate(strata_name = paste(round(crd[,"X"]),round(crd[,"Y"]),sep = "_"))


#intersection of prov_state and hexagonal grid to
# ensure that areas of polygons (and therefore area weights) reflect land area
hexagon_strata <- st_intersection(poly_grid,
                          prov_state_map) %>%
  ungroup() %>%
  group_by(strata_name) %>%
  summarise()

areastmp <- st_area(hexagon_strata)

hexagon_strata <- hexagon_strata %>%
  mutate(area = as.numeric(areastmp)/1e6)


```


Then this call to `assign_prov_state()` was throwing the CPL_geos error.

```{r}
hexagon_by_prov <- assign_prov_state(hexagon_strata)

#Error in CPL_geos_op2(op, x, y) : 
#  Evaluation error: TopologyException: Input geom 0 is invalid: Self-intersection at 6404858.7816538019 4077777.3493851377.

```
And the same error if I ran the `st_make_valid()` function on the `hexagon_strata` object before running `assign_prov_state()`

adding the `st_make_valid()` call just before the intersection seems to fix it.
